### PR TITLE
Getting started Yellow Standard: fix title

### DIFF
--- a/content/src/yellow/getting-started/yellow-standard-cm4.md
+++ b/content/src/yellow/getting-started/yellow-standard-cm4.md
@@ -1,8 +1,8 @@
 ---
 zendesk:
   article_id: 25294047501341
-  name: Home Assistant Yellow with CM4 pre-installed
-  description: Home Assistant Yellow with a Raspberry Pi Compute Module 4 preinstalled. This variant is no longer manufactured.
+  name: Home Assistant Yellow Standard (with CM4 pre-installed)
+  description: Home Assistant Yellow Standard with a Raspberry Pi Compute Module 4 preinstalled. This variant is no longer manufactured.
   position: 10
 ---
 


### PR DESCRIPTION
- to make it clearer that this is about the (discontinued) Standard model, and not the Kit model