### PR TITLE
Yellow: migrate from cm4 to cm5

### DIFF
--- a/content/src/yellow/upgrade/yellow-upgrade-cm4-cm5.md
+++ b/content/src/yellow/upgrade/yellow-upgrade-cm4-cm5.md
@@ -7,3 +7,62 @@ zendesk:
   labels: yellow, upgrade, migration
 ---
 
+## Prerequisites
+
+- Home Assistant Yellow
+- Ethernet cable
+
+Additionally, make sure you have the following items which are not part of the Kit
+
+- Raspberry Pi Compute Module 5 (CM5)
+- USB-C cable
+- Heat sink: You can use the heat sink shipped with Yellow.
+  - If you want, you can also use the Raspberry Pi Compute Module 5 Passive Cooler.
+  - **Note**: the Raspberry Pi Compute Module 5 Active Cooler is not supported on Home Assistant Yellow.
+    - There is no fan plug providing the required 5V and PWM signals.
+- If you are using PoE, make sure your router or switch provides PoE on that port
+- Optional: Power supply (12 V / 2 A, if PoE is not used)
+- Flat nose pliers
+
+  ![Image showing the Home Assistant Yellow, a Raspberry Pi Compute Module 5, Ethernet cable, power supply, a USB-C cable, and flat-nose pliers](/static/img/yellow/cm5_prereqs.jpg)
+
+## Preparing the migration
+
+{% partial 'yellow/yellow-migration-to-cm5-prep.md' %}
+
+## Opening the case
+
+{% partial 'yellow/yellow-open-case-cm5.md' %}
+
+## Removing the Raspberry Pi Compute Module 4
+
+{% partial 'yellow/yellow-remove-cm.md' %}
+
+## Seating the Raspberry Pi Compute Module 5
+
+**Notice**: Don't use screws to fix the module in place. The screws can damage the CM5 module.
+
+{% partial 'yellow/yellow-reseat-cm5.md' %}
+
+## Installing and running rpiboot
+
+{% partial 'yellow/yellow-install-rpiboot.md' %}
+
+## Installing the Home Assistant OS using Raspberry Pi Imager
+
+{% partial 'yellow/yellow-install-haos-cm5.md' %}
+
+## Reassembling your Home Assistant Yellow
+
+{% partial 'yellow/yellow-reassemble-case.md' %}
+
+## Setting up
+
+{% partial 'yellow/yellow-setup-cm5.md' %}
+
+## Related topics
+
+- [https://www.home-assistant.io/getting-started/onboarding/](https://www.home-assistant.io/getting-started/onboarding/)
+- [Raspberry Pi software](https://www.raspberrypi.com/software/)
+- [Windows installer of rpiboot](https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe)
+- [rpiboot from source code](https://github.com/raspberrypi/usbboot?tab=readme-ov-file#building)


### PR DESCRIPTION
Migrating from https://yellow.home-assistant.io/cm4-to-cm5-migrate/