### PR TITLE
Remove generation of .env file for content upload

### DIFF
--- a/.github/workflows/zendesk-deploy.yml
+++ b/.github/workflows/zendesk-deploy.yml
@@ -41,10 +41,5 @@ jobs:
         env:
           ZENDESK_API_USER: ${{ secrets.ZENDESK_API_USER }}
           ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
-
         run: |
-          touch .env
-          echo ZENDESK_API_USER=$ZENDESK_API_USER >> .env
-          echo ZENDESK_API_TOKEN=$ZENDESK_API_TOKEN >> .env
-          cd content
-          node deploy.js
+          node content/deploy.js


### PR DESCRIPTION
This seems to be unused.