### PR TITLE
Only run workflow if the repository is in the NabuCasa org

### DIFF
--- a/.github/workflows/zendesk-deploy.yml
+++ b/.github/workflows/zendesk-deploy.yml
@@ -20,6 +20,7 @@ permissions: {}
 
 jobs:
   deploy-to-zendesk:
+    if: github.repository_owner == 'NabuCasa'
     runs-on: ubuntu-latest
     steps:
       - name: Check out files from GitHub


### PR DESCRIPTION
There should be no upload attempts if this repository is forked.