### PR TITLE
Voice PE: audio on one channel only

### DIFF
--- a/content/src/voice-pe/troubleshooting/on-channel-only.md
+++ b/content/src/voice-pe/troubleshooting/on-channel-only.md
@@ -6,3 +6,16 @@ zendesk:
   labels: voice pe, troubleshooting
 ---
 
+## Symptom
+
+You connected an external speaker via the 3.5 mm (⅛”) stereo audio connector. You can hear sound, but only on one channel.
+
+![Image showing the audio jack](/static/img/voice-pe/audio_jack_faq.jpg)
+
+## Cause
+
+There is a gap between the audio connector component on the PCB and the enclosure. Depending on the plug you're using, it might not go all the way in.
+
+## Resolution
+
+Try a different cable.


### PR DESCRIPTION
content migrated from https://voice-pe.home-assistant.io/faq/#i-plugged-in-an-external-speaker-but-i-only-hear-one-channel