### PR TITLE
Add temporary noindex

### DIFF
--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -3,6 +3,7 @@
   name="google-site-verification"
   content="zfpEAeEJdY1RTn0qRWi3F-VEi-Zc0jVuzDDWJ8LdkjQ"
 />
+<meta name="robots" content="noindex" />
 <link
   href="https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap"
   rel="stylesheet"


### PR DESCRIPTION
Currently, we are blocking indexing by requiring login to access the help center. To have more control over which pages are still blocked from indexing during the migration, I am putting noindex here