### PR TITLE
Billing: move topics to separate pages

### DIFF
--- a/content/src/cloud/faq-subscription-payments/faq-lifetime-plan.md
+++ b/content/src/cloud/faq-subscription-payments/faq-lifetime-plan.md
@@ -1,0 +1,13 @@
+---
+zendesk:
+  article_id: 26179725282461
+  name: Do you offer a lifetime subscription or a one time fee?
+  position: 3
+  labels: cloud, pricing
+---
+
+No. Projecting the lifetime cost of administering a cloud service and adding/maintaining functionality seems a bit unreasonable.
+
+## Related topics
+
+- [Pricing](https://www.nabucasa.com/pricing/)

--- a/content/src/cloud/faq-subscription-payments/faq-no-payment-method.md
+++ b/content/src/cloud/faq-subscription-payments/faq-no-payment-method.md
@@ -1,0 +1,13 @@
+---
+zendesk:
+  article_id: 26179726556701
+  name: What happens if I don't enter a payment method?
+  position: 5
+  labels: cloud
+---
+
+You will lose access if you did not enter a payment method by the time that your trial expires.
+
+## Related topics
+
+- [Pricing](https://www.nabucasa.com/pricing/)

--- a/content/src/cloud/faq-subscription-payments/faq-update-billing-address.md
+++ b/content/src/cloud/faq-subscription-payments/faq-update-billing-address.md
@@ -1,0 +1,12 @@
+---
+zendesk:
+  article_id: 26179743752733
+  name: I moved, how do I update my billing address?
+  position: 6
+  labels: cloud
+---
+
+1. Log in to your [Nabu Casa account](https://account.nabucasa.com/) and select **Manage account**.
+2. Under **Billing information**, fill in the required details.
+3. To apply the change, select **Update billing information**.
+   - Note that your new payment method will be applied from the following (monthly or yearly) payments onward.

--- a/content/src/cloud/faq-subscription-payments/managing-payments.md
+++ b/content/src/cloud/faq-subscription-payments/managing-payments.md
@@ -6,18 +6,6 @@ zendesk:
   labels: cloud
 ---
 
-## Do you offer a lifetime plan or a one time fee?
-
-No. Projecting the lifetime cost of administering a cloud service and adding/maintaining functionality seems a bit unreasonable.
-
-## What happens if I don't enter a payment method?
-
-You will lose access if you did not enter a payment method by the time that your trial expires.
-
-## I moved, how do I update my billing address?
-
-You can update the address used on invoices by going yo the [account page](https://account.nabucasa.com/). There is a "Update billing information" section you can adjust this on.
-
 ## I want my VAT number to be attached on the invoice
 
 We strictly operate as a business-to-consumer provider, as such we can not attach your VAT number to the invoice.


### PR DESCRIPTION
move each section into its own topic, so that it can be found more easily, as zendesk searches page titles