### PR TITLE
yellow rpiboot: add code fence

### DIFF
--- a/_includes/yellow/yellow-install-rpiboot.md
+++ b/_includes/yellow/yellow-install-rpiboot.md
@@ -48,7 +48,12 @@
 1. On your PC, run rpiboot and let it run through.
    - If you are using Windows, it might ask you if you want to reformat the disk. Select **Cancel** each time.
    - If you are running an Apple Silicon mac, before running rpiboot, make sure you open the terminal using the “Rosetta” compatibility mode.
-   - If you are using Linux or macOS, use `sudo ./rpiboot -d mass-storage-gadget64` to run the tool.
+   - If you are using Linux or macOS, use the following command to run the tool.
+
+     ```bash
+     sudo ./rpiboot -d mass-storage-gadget64
+     ```
+
 2. After a few seconds, the yellow LED on the Yellow board should start blinking.
 3. Afterwards, only the green LED should be on.
 4. The module is now ready to have the Home Assistant Operating System installed on it (next steps).


### PR DESCRIPTION
addresses issue raised in <https://github.com/NabuCasa/support/pull/484#discussion_r2081300365>

it uses codefence now, but it causes the entire step section fall out of the right-hand column, down into a new line

![image](https://github.com/user-attachments/assets/38ab6894-f37a-451b-a1cf-b31947a7146a)
