### PR TITLE
VPE disassemble: add tags to apply new style

### DIFF
--- a/src/voice-pe/customizing/disassemble.md
+++ b/src/voice-pe/customizing/disassemble.md
@@ -12,11 +12,18 @@ Follow these steps if you have 3D-printed your own enclosure parts and now want 
 
 ## Prerequisites
 
+{% steps %}
+{% step " " " " %}
+{% image "/static/img/voice-pe/voice_disassembly_prereq_small.jpg" "Home Assistant Voice Preview Edition and screw drivers" %}
+{% stepContent %}
+
 - Home Assistant Voice Preview Edition
 - No 1 and 2 crosshead screwdriver
 - No 4 flathead screwdriver
 
-   ![Home Assistant Voice Preview Edition and screw drivers](/static/img/voice-pe/voice_disassembly_prereq_small.jpg)
+{% endstepContent %}
+{% endstep %}
+{% endsteps %}
 
 ## Disassembling the device enclosure
 


### PR DESCRIPTION
- applies style from https://github.com/NabuCasa/support/pull/510, which allows to have the image in a separate column without adding the **step** title

https://deploy-preview-516--nabucasa-support-content.netlify.app/articles/25938306296605

![image](https://github.com/user-attachments/assets/a4b06141-6ebc-4ced-b32e-5d77778ad293)
