### PR TITLE
Thread: remove Notice specific to Supervised installation type

### DIFF
--- a/src/connect-zbt-1/thread/thread-enable.md
+++ b/src/connect-zbt-1/thread/thread-enable.md
@@ -21,7 +21,6 @@ This guide assumes you have the following setup:
 - [Home Assistant Operating System](https://www.home-assistant.io/docs/glossary/#home-assistant-operating-system) installation.
 - You don't have Multiprotocol enabled. If you do, disable it by following the steps in the procedure on [disabling multiprotocol support](/hc/en-us/articles/26124969612445).
 - **Important:** This guide installs firmware that supports only Thread! If you use your Connect ZBT-1 to control Zigbee devices, you will no longer be able to control them after installing the Thread firmware.
-- **Notice:** [Home Assistant Supervised](https://www.home-assistant.io/docs/glossary/#home-assistant-supervised) installation type: The Thread border router has specific requirements for IPv6 configuration (for example, IPv6 routing needs to be enabled). The add-on is being tested on the [Home Assistant Operating System](https://www.home-assistant.io/docs/glossary/#home-assistant-operating-system). If you experience connectivity issues, try using a Home Assistant OS installation.
 
 {% endstepContent %}
 {% endprereq %}


### PR DESCRIPTION
Do not merge. Requires approval by puddly

Thread: remove Notice specific to Supervised installation type

- as Supervised installation type has been deprecated
- home-assistant/architecture#1197, and home-assistant/architecture#1198 https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems