### PR TITLE
Add debug logging instructions for certificate issues

### DIFF
--- a/src/cloud/troubleshooting-remote-ui/remote-access-is-being-prepared.md
+++ b/src/cloud/troubleshooting-remote-ui/remote-access-is-being-prepared.md
@@ -48,4 +48,20 @@ If the problem persists, try resetting your Home Assistant Cloud data and reques
 5. Once Home Assistant restarts, go back to the **Home Assistant Cloud** page and sign in with your Nabu Casa credentials.
 6. Wait a few minutes while Home Assistant attempts to request and download a new SSL certificate for your remote URL.
 
-If resetting cloud data **did not resolve the issue**, **do not reset it again**. Instead, contact Nabu Casa support.
+If resetting cloud data **did not resolve the issue**, **do not reset it again**. Instead, enable debug logging to help diagnose the problem:
+
+1. Add the following logger configuration to your `configuration.yaml` file:
+
+   ```yaml
+   logger:
+     default: info
+     logs:
+       homeassistant.components.cloud: debug
+       hass_nabucasa: debug
+       acme: debug
+       snitun: debug
+   ```
+
+2. Restart Home Assistant and allow it to run for approximately 15 minutes.
+3. Download the Home Assistant core logs from [**Settings** > **System** > **Logs**](https://my.home-assistant.io/redirect/logs/).
+4. Contact Nabu Casa support and include the downloaded logs with your support request. The debug information will help identify the root cause of the certificate generation issue.


### PR DESCRIPTION
Adds debug logging instructions to the "Remote control is being prepared" troubleshooting document to help diagnose certificate generation issues.

## Changes
- Added a new section that instructs users to enable debug logging when cloud data reset doesn't resolve the issue

## Why
The current troubleshooting steps don't always resolve certificate issues, and support needs debug logs to identify root causes. This addition helps users provide the necessary diagnostic information upfront.