### PR TITLE
Zigbee: fix typo

### DIFF
--- a/src/connect-zbt-1/faq-about-the-product/faq-does-it-support-z-wave.md
+++ b/src/connect-zbt-1/faq-about-the-product/faq-does-it-support-z-wave.md
@@ -6,4 +6,4 @@ zendesk:
   labels: connect zbt-1, faq
 ---
 
-No, Home Assistant Connect ZBT-1 does not support Z-Wave. ZBT stands for ZigBee and Thread.
+No, Home Assistant Connect ZBT-1 does not support Z-Wave. ZBT stands for Zigbee and Thread.


### PR DESCRIPTION
We are using Zigbee in the documentation, not ZigBee.