### PR TITLE
Update five support articles: custom domain, SD card reset, password reset, multi-account FAQ

### DIFF
--- a/src/cloud/faq-ha-cloud/faq-cloud-single-account-for-multiple-instances.md
+++ b/src/cloud/faq-ha-cloud/faq-cloud-single-account-for-multiple-instances.md
@@ -6,4 +6,22 @@ zendesk:
   labels: cloud
 ---
 
-No, this is not possible. Each Home Assistant instance requires its own separate account and subscription. While Home Assistant will display a warning if you attempt to use the same account on multiple instances, doing so causes unpredictable behavior, only one instance will have active service (usually the last one to restart), leaving your other instances without cloud access. This has resulted in many users unexpectedly losing remote access to distant Home Assistant installations. For reliable service, each instance needs its own dedicated subscription.
+No. Each Home Assistant installation requires its own Nabu Casa account and subscription.
+
+Using the same account on multiple instances causes unpredictable behavior — only one instance will have active service at a time (usually the last one to connect), leaving your other installations without cloud access.
+
+## Setting up a second subscription
+
+You'll need a separate email address for the second account. If your email provider supports aliases — for example, Gmail's `+` addressing, Apple Hide My Email, or a dedicated alias service — that works perfectly. You don't need a completely separate email account.
+
+Note that alias emails may be rejected by our system's anti-abuse detection. If you run into trouble creating the account, contact support and we can create it for you manually.
+
+Once you have the second account, subscribe at nabucasa.com and sign in to Home Assistant Cloud on your second instance with those credentials.
+
+## Are there discounts for multiple subscriptions?
+
+No. The subscription is priced as low as possible. Home Assistant Cloud exists to fund the development of the free, open-source Home Assistant project — not as a commercial service. There are no multi-instance discounts.
+
+## Related topics
+
+- [Home Assistant Cloud pricing](https://www.nabucasa.com/pricing/)

--- a/src/cloud/remote-access/remote-access-with-custom-domain.md
+++ b/src/cloud/remote-access/remote-access-with-custom-domain.md
@@ -6,7 +6,7 @@ zendesk:
   labels: cloud
 ---
 
-If you own your own domain (like `example.com`), you might want to use a subdomain of that domain name (like `home.example.com`) to have a familiar URL to your Home Assistant instance, in addition to the default one that is provided when you [enable Home Assistant remote access](/hc/en-us/articles/26474279202973/).
+If you own your own domain (like `example.com`), you might want to use a subdomain of that domain name (like `home.example.com`) to have a familiar URL to access Home Assistant, in addition to the default one that is provided when you [enable Home Assistant remote access](/hc/en-us/articles/26474279202973/).
 
 ## Prerequisites
 
@@ -23,9 +23,46 @@ If you own your own domain (like `example.com`), you might want to use a subdoma
         In most cases, you do **not** repeat the main domain (`example.com`) as your DNS provider already stores it separately.
    - **Record Type**: `CNAME`
    - **Data / Value / Target / Points to**: The value shown as the CNAME target on the Nabu Casa page. Copy it exactly as shown.
+
+   For example, if your desired address is `home.example.com`, the two records look like this (your actual values will use the UUID from your Nabu Casa remote URL):
+
+   | Name / Host | Type | Value / Target |
+   |---|---|---|
+   | `home` | CNAME | `abcd1234-ef56-7890-abcd-ef1234567890.ui.nabu.casa` |
+   | `_acme-challenge.home` | CNAME | `_acme-challenge.abcd1234-ef56-7890-abcd-ef1234567890.ui.nabu.casa` |
+
+   Note that both records use the same instance ID. The `_acme-challenge` record simply adds `_acme-challenge.` to both the name and the value.
+
 6. Save your DNS changes. It can take several minutes or longer before the new records are visible on the internet.
 7. Return to the Nabu Casa page and select **Validate** until both records show as validated. This may take several minutes.
-8. To start using the updated certificate, restart your Home Assistant instance.
+8. To start using the updated certificate, restart Home Assistant.
+
+## Already set up? Look up your CNAME record values
+
+If you've previously configured a custom domain and need to verify or recreate your DNS records, the values are derived directly from your Nabu Casa remote URL.
+
+Find your remote URL on the [Nabu Casa account page](https://account.nabucasa.com) under Remote access. It looks like `https://abcd1234-ef56-7890-abcd-ef1234567890.ui.nabu.casa`. Your two CNAME records use that URL — without the `https://` prefix — as follows:
+
+| Name / Host | Type | Value / Target |
+|---|---|---|
+| `home` | CNAME | `abcd1234-ef56-7890-abcd-ef1234567890.ui.nabu.casa` |
+| `_acme-challenge.home` | CNAME | `_acme-challenge.abcd1234-ef56-7890-abcd-ef1234567890.ui.nabu.casa` |
+
+The main record is your remote URL without `https://`. The `_acme-challenge` record is the same value with `_acme-challenge.` added to the front.
+
+## Troubleshooting
+
+### Validation stays pending after DNS records look correct
+
+DNS checker sites may show your records as correct before Let's Encrypt — which validates the ACME challenge from its own resolvers — has seen the update. If the Nabu Casa page still shows the `_acme-challenge` record as unvalidated, wait a few minutes longer and try again. Let's Encrypt propagation can lag behind what general DNS checkers report.
+
+### Using Cloudflare as your DNS provider
+
+If your domain is managed through Cloudflare, set both CNAME records to **DNS only** (grey cloud icon), not proxied (orange cloud). Cloudflare's proxy intercepts HTTPS traffic and will prevent the TLS connection and the ACME challenge validation from working.
+
+### DNSSEC
+
+If your domain has DNSSEC enabled, it must be fully and correctly configured. A partial or inconsistent DNSSEC setup causes Let's Encrypt validation to fail even when the DNS records themselves appear correct. If you're not sure of your DNSSEC status, disabling it is the quickest way to rule it out.
 
 ## Related topics
 

--- a/src/green/troubleshooting/forgot-owner-password.md
+++ b/src/green/troubleshooting/forgot-owner-password.md
@@ -14,15 +14,11 @@ If you forgot the owner's password, you need to connect an external monitor and 
 
 2. Reset the password via the terminal.
 
-   - Enter the following command: `auth reset --username 'existing_user' --password 'new_password'`
+   - Enter `auth reset --interactive`. It will show you a list of users on the system — select yours, then enter a new password when prompted.
 
      **Info**: The ha command line does not support all special characters.
      - When resetting via the command line, use a short and simple password without special characters.
      - Once reset, go and replace it with a complex one in the UI.
-
-     **Example**: To reset the password for the user `yelena` to `12345`, enter: `auth reset --username 'yelena' --password '12345'`
-
-     ![Clip showing how to enter the command into the command line](/static/img/green/home-assistant-cli.webp)
 
 3. Log in with the new password.
 

--- a/src/green/troubleshooting/resetting-the-device-using-sd-card.md
+++ b/src/green/troubleshooting/resetting-the-device-using-sd-card.md
@@ -62,14 +62,9 @@ This process clears the data disk on your Green. Unless you [create a backup](ht
 {% image "/static/img/green/download-circle-outline.svg" "Downloading the required software" %}
 {% stepContent %}
 
-1. To download the Home Assistant Green OS installer, paste this into your browser.
-
-    ```text
-    https://github.com/NabuCasa/buildroot-installer/releases/tag/green-installer-20240410
-    ```
-
-2. To start the download, select the file *green-installer-20240410.img.xz*.
-3. Download and start [Balena Etcher](https://www.balena.io/etcher).
+1. Download the Home Assistant Green OS installer: [green-installer-20240410.img.xz](https://github.com/NabuCasa/buildroot-installer/releases/download/green-installer-20240410/green-installer-20240410.img.xz)
+   - This file is hosted on the [NabuCasa buildroot-installer releases page](https://github.com/NabuCasa/buildroot-installer/releases/tag/green-installer-20240410) on GitHub.
+2. Download and start [Balena Etcher](https://www.balena.io/etcher).
    - You may need to run it with administrator privileges on Windows.
 
 {% endstepContent %}
@@ -136,7 +131,7 @@ This process clears the data disk on your Green. Unless you [create a backup](ht
 {% image "/static/img/green/green_reset_insert_sd.webp" "Inserting the SD card" %}
 {% stepContent %}
 
-- Insert the SD card with the Home Assistant Green OS installer.
+- Insert the SD card with the Home Assistant Green OS installer. Push it in until you hear a click — the slot is spring-loaded and the card must be fully seated.
 - Make sure the Home Assistant Green is connected to the Internet.
 
 {% endstepContent %}

--- a/src/yellow/troubleshooting/faq-forgot-owner-password-yellow.md
+++ b/src/yellow/troubleshooting/faq-forgot-owner-password-yellow.md
@@ -11,13 +11,10 @@ If you forgot the owner's password, you need to reset the password via a termina
 
 1. To connect a terminal using a Windows computer, follow the steps on [using the serial console for debugging (Windows)](/hc/en-us/articles/25454894609693) up to (and including) step 9.
 2. To connect a terminal using a Mac or Linux computer, follow the steps on [using the serial console for debugging (Linux/macOS)](/hc/en-us/articles/25454972435357) up to (and including) step 9.
-3. To reset the password, enter `auth reset --username 'existing_user' --password 'new_password'`.
+3. To reset the password, enter `auth reset --interactive`. It will show you a list of users on the system — select yours, then enter a new password when prompted.
    - **Info**: The ha command line doesn't support all special characters.
      - When resetting via the command line, use a short and simple password without special characters.
      - Once reset, go and replace it with a complex one in the UI.
-   - **Example**: To reset the password for the user `yelena` to `12345`, enter `auth reset --username 'yelena' --password '12345'`.
-
-     ![Clip showing how to enter the command into the command line](/static/img/yellow/home-assistant-cli.webp)
 
 4. Log in with the new password.
 5. Go to your [User profile](https://my.home-assistant.io/redirect/profile/) and, on the **Security** tab, update the password to a more complex one.


### PR DESCRIPTION
## Summary

- **Custom domain**: Added CNAME example tables in the setup steps and a post-setup reference section ("Already set up? Look up your CNAME values"). Added troubleshooting section covering Cloudflare proxy (must be DNS only), Let's Encrypt propagation lag vs DNS checkers, and DNSSEC. Removed "instance" terminology throughout.
- **SD card reset (Green)**: Direct download link to the `.img.xz` file instead of navigate-and-click. SD card insertion step now calls out the spring-loaded slot and click.
- **Forgot password (Green + Yellow)**: Switched to `auth reset --interactive` with explanation of the user-list selection flow. Removed outdated `--username`/`--password` example syntax and accompanying gif.
- **Single account / multiple instances FAQ**: Expanded from a single paragraph to a structured article with setup guidance (email aliases), anti-abuse note, and pricing explanation.

## Notes

- The `auth reset --interactive` command description ("shows a list of users, select yours, enter new password") should be verified against current HA CLI behavior before merge.
- The multi-account article uses "instance" and "installation" inconsistently — left for reviewer to decide preferred term.
- Dependabot vulnerabilities flagged on default branch are pre-existing, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)