### PR TITLE
Update ZWA-2 FAQ: Wi-Fi and Bluetooth proxy available via Portable firmware

### DIFF
--- a/src/connect-zwa-2/faq/does-it-support-zigbee.md
+++ b/src/connect-zwa-2/faq/does-it-support-zigbee.md
@@ -6,8 +6,16 @@ zendesk:
   labels: connect-zwa-2, supported protocols
 ---
 
-- No, Home Assistant Connect ZWA-2 doesn't support Zigbee, Wi-Fi, Bluetooth, or Thread.
+Home Assistant Connect ZWA-2 is a Z-Wave adapter. It does not support Zigbee or Thread.
+
+Wi-Fi and Bluetooth are available only with the experimental [Portable Z-Wave firmware](https://toolbox.openhomefoundation.org/home-assistant-connect-zwa-2/):
+
+- **Wi-Fi**: The ZWA-2 connects to Home Assistant over Wi-Fi instead of USB, allowing placement anywhere in your home.
+- **Bluetooth proxy**: When using Portable firmware, the ZWA-2 can also act as a Bluetooth proxy for Home Assistant. This is disabled by default and can be enabled from the device page in Home Assistant.
+
+Portable firmware is experimental and not the standard configuration. Most users should use the default USB controller firmware.
 
 ## Related topics
 
 - [Home Assistant Connect ZWA-2 product page](https://www.home-assistant.io/connect/zwa-2/)
+- [Use ZWA-2 with Wi-Fi or PoE](/hc/en-us/articles/34864630493469)


### PR DESCRIPTION
## What changed

The FAQ article "Does ZWA-2 support Zigbee, Wi-Fi, Bluetooth, or Thread?" previously answered with a flat "no" to all four protocols. That was accurate for the standard USB firmware but became incorrect once Portable Z-Wave firmware shipped.

**Before:**
> No, Home Assistant Connect ZWA-2 doesn't support Zigbee, Wi-Fi, Bluetooth, or Thread.

**After:** Zigbee and Thread remain unsupported. Wi-Fi and Bluetooth proxy are available with the experimental Portable firmware, with a clear steer toward standard USB for most users.

## Details

- Portable firmware is still `experimental` (confirmed in OHF Toolbox source, version 26.3.0 as of March 2026)
- BT proxy is Portable-only — standard USB firmware is Z-Wave only
- Added link to the existing "Use with Wi-Fi or PoE" getting-started article (article 34864630493469)
- OHF Toolbox link for flashing: https://toolbox.openhomefoundation.org/home-assistant-connect-zwa-2/