### PR TITLE
Clarify that HA Cloud's Assistant integration doesn't also require Remote Access

### DIFF
--- a/src/cloud/voice-assistants/google-assistant.md
+++ b/src/cloud/voice-assistants/google-assistant.md
@@ -40,6 +40,8 @@ To control Home Assistant entities from Google Home, follow these steps:
      - There you can add **Home Assistant Cloud by Nabu Casa** using the **Add devices** option.
    - Troubleshooting: If after adding **Home Assistant Cloud by Nabu Casa**, the message _No compatible devices were found in your Home Assistant Cloud by Nabu Casa_ appears: This means no entity was exposed to Google Assistant. Repeat the step on exposing entities.
 
+Note that Home Assistant Cloud's Google Assistant integration does not also require you to enable Remote Access.
+
 ## Available domains
 
 Currently, the following domains are available to be used with Google Assistant. They are listed with their default types:


### PR DESCRIPTION
This pull request can be merged on its own, but I would encourage Nabu Casa engineers or support to expand upon what I am adding here. I just don't have any information myself on how this works in detail. I also only personally know and use Google Assistant, but I'm guessing parts of this apply to other voice assistant integrations.

I have long assumed that Home Assistant Cloud's automatic Google Assistant integration also required you to enable Remote Access, but support just confirmed to me that this is not true. It seems you can enable Home Assistant Cloud's Google Assistant integration but keep Remote Access disabled, and everything works just fine.

My previous belief was based on the fact that the general Home Assistant documentation (https://www.home-assistant.io/integrations/google_assistant/) states that, for a manually configured setup, "To use Google Assistant, your Home Assistant configuration has to be [externally accessible with a hostname and SSL certificate](https://www.home-assistant.io/docs/configuration/remote/)." In other words, the Home Assistant documentation does not provide any instructions for enabling Google Assistant without something like Remote Access, so I assumed it was not possible for some reason that was yet unclear to me.

The Home Assistant Cloud documentation also does not detail how "Google Assistant on + Remote Access off" works anywhere. In that setup, is there still a limited reverse proxy hosted by Nabu Casa which only exposes the specific endpoints required by Google Assistant? If not, how else does it work?

If there is still a limited reverse proxy in place, then it seems like the docs should very clearly say that even if you have Remote Access off, your HA instance is (I'm guessing here now) exposed to the Internet through a Nabu Casa-managed reverse proxy but only the specific endpoints needed for those voice assistants. The Nabu Casa proxy URL is also only displayed in the Home Assistant config pages under Remote Access, which leads the user to believe that the proxy is only ever enabled if Remote Access is on. It is now unclear if that is true or not.