### PR TITLE
Add June 10 billing maintenance window details

### DIFF
--- a/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
+++ b/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
@@ -15,7 +15,31 @@ In June 2026, we updated the Nabu Casa account management portal at [account.nab
 - Underlying billing infrastructure has been updated to support future improvements.
 - Going forward, the payment reference shown on your bank or financial institution statement may look slightly different depending on the payment method you have selected.
 
+## Billing maintenance window
+
+As part of this update, billing will be paused for a scheduled maintenance window. Any payments due during this window will be temporarily delayed and processed automatically once the maintenance window ends. No action is required on your part.
+
+The maintenance window is scheduled to run from **June 10, 2026 at 07:00 to June 11, 2026 at 07:00**, Central European Summer Time (CEST).
+
+| Time zone | Start | End |
+|---|---|---|
+| CEST — Central Europe | June 10 at 07:00 | June 11 at 07:00 |
+| UTC | June 10 at 05:00 | June 11 at 05:00 |
+| BST — UK / Ireland | June 10 at 06:00 | June 11 at 06:00 |
+| EDT — US East Coast | June 10 at 01:00 | June 11 at 01:00 |
+| PDT — US West Coast | June 9 at 22:00 | June 10 at 22:00 |
+
+{% callout "important" %}
+If your payment is due during the maintenance window, it will not be lost or cancelled. It will be processed as soon as billing resumes.
+{% endcallout %}
+
+For the most up-to-date information, including any changes to the schedule, check the [maintenance listing on the Nabu Casa status page](https://status.nabucasa.com/incidents/t56zhmmz4jkz).
+
 ## FAQs
+
+### What if I'm billed during the maintenance window?
+
+If your payment is scheduled during the maintenance window, it will be held and processed automatically once billing resumes. You will not be charged twice and your subscription will not be cancelled. No action is required.
 
 ### My account page isn't loading — I use a DNS ad blocker (Pi-hole / AdGuard Home)
 
@@ -38,3 +62,4 @@ To resolve this, add the following domains to your DNS blocker's allowlist:
 
 - [Nabu Casa account page](https://account.nabucasa.com)
 - [Nabu Casa status page](https://status.nabucasa.com)
+- [June 2026 billing maintenance window](https://status.nabucasa.com/incidents/t56zhmmz4jkz)

--- a/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
+++ b/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
@@ -23,11 +23,11 @@ The maintenance window is scheduled to run from **June 10, 2026 at 07:00 to June
 
 | Time zone | Start | End |
 |---|---|---|
-| CEST — Central Europe | June 10 at 07:00 | June 11 at 07:00 |
-| UTC | June 10 at 05:00 | June 11 at 05:00 |
-| BST — UK / Ireland | June 10 at 06:00 | June 11 at 06:00 |
-| EDT — US East Coast | June 10 at 01:00 | June 11 at 01:00 |
-| PDT — US West Coast | June 9 at 22:00 | June 10 at 22:00 |
+| CEST — Central Europe | June 10 at 05:00 | June 11 at 07:00 |
+| UTC | June 10 at 03:00 | June 11 at 05:00 |
+| BST — UK / Ireland | June 10 at 04:00 | June 11 at 06:00 |
+| EDT — US East Coast | June 9 at 23:00 | June 11 at 01:00 |
+| PDT — US West Coast | June 9 at 20:00 | June 10 at 22:00 |
 
 {% callout "important" %}
 If your payment is due during the maintenance window, it will not be lost or cancelled. It will be processed as soon as billing resumes.

--- a/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
+++ b/src/cloud/nabu-casa-account/2026-june-new-account-ui.md
@@ -19,7 +19,7 @@ In June 2026, we updated the Nabu Casa account management portal at [account.nab
 
 As part of this update, billing will be paused for a scheduled maintenance window. Any payments due during this window will be temporarily delayed and processed automatically once the maintenance window ends. No action is required on your part.
 
-The maintenance window is scheduled to run from **June 10, 2026 at 07:00 to June 11, 2026 at 07:00**, Central European Summer Time (CEST).
+The maintenance window is scheduled to run from **June 10, 2026 at 05:00 to June 11, 2026 at 07:00**, Central European Summer Time (CEST).
 
 | Time zone | Start | End |
 |---|---|---|


### PR DESCRIPTION
Adds the billing maintenance window section to the June 2026 new account UI article, now that the date is confirmed.

These details were removed from #883 while the date was pending. This PR reintroduces them against `main` (now that #883 has merged).

## What's added
- **Billing maintenance window** section with the confirmed schedule (**June 10, 2026 at 07:00 to June 11, 2026 at 07:00 CEST**) and a multi-timezone table.
- FAQ: "What if I'm billed during the maintenance window?"
- Related topics link to the status page maintenance listing.

Wording states the schedule as confirmed (no longer tentative); the status-page link still covers any future schedule changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)