### PR TITLE
Clarify migration limitations for Zigbee migrations

### DIFF
--- a/_includes/fragments/zbt-1-2-not-possible-to-migrate-all.md
+++ b/_includes/fragments/zbt-1-2-not-possible-to-migrate-all.md
@@ -1,8 +1,9 @@
 
-**Not possible to migrate all settings and devices**
+**Be aware that not all application configurations can be migrated!**
 
-This procedure only helps migrate basic network settings to {{ productName }}.
+These steps help migrate your Zigbee network, meaning you will not have to pair all your devices again, however, some higher-level application configurations is not possible to migrate.
 
-- Customizations like device names will be lost and automations will need to be updated.
-- Most powered devices like light bulbs will be re-discovered over time (you can speed this up by power-cycling the device) but your battery-powered devices may need to be re-joined to the network for the migration to complete.
-- There is currently no migration path to migrate all settings and devices.
+- This procedure only helps migrate basic network settings to {{ productName }} (Zigbee adapter).
+- Customizations like device names will be lost and automations will need to be updated manually.
+- Most powered devices like light bulbs will be re-discovered over time (you can speed this up by power-cycling the device), but your battery-powered devices may need to be re-joined manually to the network for the migration to complete.
+- There is currently no migration path to migrate high-level application settings and devices.


### PR DESCRIPTION
Updated note for migration instructions to clarify that high-level application configurations or customizations can not migrated and provided further explaination on the limitations regarding device names and automations.

Also related to PR https://github.com/NabuCasa/support/pull/903 where some of the missing text was moved to this reusable fragement.

Reference directly question raised here which show this is not clear:

* https://github.com/zigpy/zigpy/issues/1842

