### PR TITLE
Apply reuse of fragment that clearify not possible to migrate all

### DIFF
--- a/_includes/fragments/zbt-1-2-migrate-from-backup-intro.md
+++ b/_includes/fragments/zbt-1-2-migrate-from-backup-intro.md
@@ -4,9 +4,8 @@ Follow these instructions if you are in the following situation:
 - you no longer have the original adapter,
 - and you want to migrate to {{ productName }}.
 
-Please note that not all settings can be migrated:
+{% callout "note" %}
 
-- These steps help migrate the network, meaning you won't have to pair all your devices again with {{ productName }}.
-- However, some higher-level settings cannot be migrated.
-  - Elements such as device names will be lost.
-  - There is currently no migration path to transfer all settings.
+{% include 'fragments/zbt-1-2-not-possible-to-migrate-all.md' %}
+
+{% endcallout %}


### PR DESCRIPTION
Updated migration instructions to call oout reuse of fragment that clearify not possible to migrate all not all settings can be migrated and included a reference to the limitations.

This is reused in the other migration documentation pages.

Also related to PR https://github.com/NabuCasa/support/pull/902 which merged some of the missing text from this to the reusable fragement.