### PR TITLE
Support both port 80 and :8123 in Green and Yellow access instructions

### DIFF
--- a/src/green/getting-started/setting-up-the-device.md
+++ b/src/green/getting-started/setting-up-the-device.md
@@ -70,9 +70,11 @@ This sections shows you how to setup your device and get started with Home Assis
 
    3. Select your Home Assistant server.
 
-      **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`
+      **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`
 
-      **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+      **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+      **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
 
    4. The Home Assistant user interface guides you through the initial onboarding.
 
@@ -86,4 +88,4 @@ This sections shows you how to setup your device and get started with Home Assis
 
 - [Home Assistant Onboarding](https://www.home-assistant.io/getting-started/onboarding/)
 - [About the LEDs](/hc/en-us/articles/25210352599197)
-- [I can't access the system via http://homeassistant.local:8123](/hc/en-us/articles/25140903526301)
+- [I can't access the system via http://homeassistant.local](/hc/en-us/articles/25140903526301)

--- a/src/green/getting-started/start-up-after-power-off.md
+++ b/src/green/getting-started/start-up-after-power-off.md
@@ -47,8 +47,10 @@ There are 2 different start up procedures, depending on the current state of you
 {% stepContent %}
 
    - Select your Home Assistant server:
-      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`
-      - **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`
+      - **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+      - **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
 
 {% endstepContent %}
 {% endstep %}
@@ -83,8 +85,10 @@ Follow these steps if you want to start up the system after it has been powered 
 {% stepContent %}
 
    - Select your Home Assistant server:
-      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`.
-      - **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`.
+      - **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+      - **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
 
 {% endstepContent %}
 {% endstep %}

--- a/src/green/troubleshooting/faq-cant-access-the-system.md
+++ b/src/green/troubleshooting/faq-cant-access-the-system.md
@@ -1,12 +1,12 @@
 ---
 zendesk:
   article_id: 25140903526301
-  name: I can’t access Home Assistant Green via http://homeassistant.local:8123.
+  name: I can’t access Home Assistant Green via http://homeassistant.local.
   position: 10
   labels: green, troubleshooting
 ---
 
-1. If [http://homeassistant.local:8123](http://homeassistant.local:8123) doesn't work, try [http://homeassistant:8123](http://homeassistant:8123). If that does not help, you may be able to find the IP address of Home Assistant Green on your router. The URL will be `http://<IP ADDRESS>:8123`.
+1. Try [http://homeassistant.local](http://homeassistant.local) first, and if that doesn't load, try [http://homeassistant.local:8123](http://homeassistant.local:8123). Home Assistant uses one of these two ports depending on how and when it was installed. If neither works, try `http://homeassistant` or `http://homeassistant:8123`. If that does not help, you may be able to find the IP address of Home Assistant Green on your router. The URL will be `http://<IP ADDRESS>` or `http://<IP ADDRESS>:8123`.
 
 2. Check if the Home Assistant Green is plugged in and the yellow LED blinks in a heartbeat pattern. For more information on the LED patterns, see [Home Assistant Green LEDs](https://green.home-assistant.io/documentation/green-leds/).
 

--- a/src/green/troubleshooting/resetting-the-device-using-sd-card.md
+++ b/src/green/troubleshooting/resetting-the-device-using-sd-card.md
@@ -177,8 +177,10 @@ This process clears the data disk on your Green. Unless you [create a backup](ht
 
 1. Install the app: To access Home Assistant from your mobile device, use the QR code to locate the app in the app store.
 2. Select your Home Assistant server:
-   - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`.
-   - **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+   - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`.
+   - **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+   - **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
 3. The Home Assistant user interface guides you through the initial onboarding.
    - **Info**: For further information, refer to the instructions provided.
 
@@ -190,5 +192,5 @@ This process clears the data disk on your Green. Unless you [create a backup](ht
 
 - [Creating a backup](/hc/en-us/articles/25154828325917)
 - [Onboarding](https://www.home-assistant.io/getting-started/onboarding/)
-- [Can't access homeassistant.local:8123](/hc/en-us/articles/25140903526301)
+- [Can't access homeassistant.local](/hc/en-us/articles/25140903526301)
 - [Resetting the device without SD card (OS version 13.1 and later)](/hc/en-us/articles/25161225495837)

--- a/src/green/troubleshooting/resetting-the-device.md
+++ b/src/green/troubleshooting/resetting-the-device.md
@@ -92,8 +92,10 @@ If you're unsure what's causing your issue, consider asking the [Home Assistant 
    1. Installing the app.
       - To access Home Assistant from your mobile device, use the QR code to locate the app in the app store.
    2. Selecting your Home Assistant server.
-      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`
-      - **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+      - **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`
+      - **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+      - **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
    3. The Home Assistant user interface guides you through the initial onboarding.
 
       - **Info** For further information, refer to the instructions.
@@ -109,4 +111,4 @@ If you're unsure what's causing your issue, consider asking the [Home Assistant 
 
 - [Creating a backup](/hc/en-us/articles/25154828325917)
 - [Onboarding](https://www.home-assistant.io/getting-started/onboarding/)
-- [Can't access homeassistant.local:8123](/hc/en-us/articles/25140903526301)
+- [Can't access homeassistant.local](/hc/en-us/articles/25140903526301)

--- a/src/yellow/getting-started/yellow-standard-cm4.md
+++ b/src/yellow/getting-started/yellow-standard-cm4.md
@@ -63,9 +63,11 @@ zendesk:
 
 3. Select your Home Assistant server.
 
-  **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196:8123`
+  **Mobile**: Confirm the IP address detected by the app. For example `http://192.168.1.196`
 
-  **Desktop**: Visit [http://homeassistant.local:8123](http://homeassistant.local:8123) to access the Home Assistant user interface.
+  **Desktop**: Visit [http://homeassistant.local](http://homeassistant.local) to access the Home Assistant user interface.
+
+  **Info**: If that address doesn't load, add `:8123` to the end of either address. Home Assistant uses one of these two ports depending on how and when it was installed.
 
 4. The Home Assistant user interface guides you through the initial onboarding.
 

--- a/src/yellow/troubleshooting/faq-cant-access-the-system-yellow.md
+++ b/src/yellow/troubleshooting/faq-cant-access-the-system-yellow.md
@@ -1,12 +1,12 @@
 ---
 zendesk:
   article_id: 25455199250589
-  name: I can’t access the system via http://homeassistant.local:8123.
+  name: I can’t access the system via http://homeassistant.local.
   position: 10
   labels: yellow, troubleshooting
 ---
 
-1. If [http://homeassistant.local:8123](http://homeassistant.local:8123) doesn't work, try [http://homeassistant:8123](http://homeassistant:8123). If that does not help, you may be able to find the IP address of Home Assistant Yellow on your router. The URL will be `http://<IP ADDRESS>:8123`.
+1. Try [http://homeassistant.local](http://homeassistant.local) first, and if that doesn't load, try [http://homeassistant.local:8123](http://homeassistant.local:8123). Home Assistant uses one of these two ports depending on how and when it was installed. If neither works, try `http://homeassistant` or `http://homeassistant:8123`. If that does not help, you may be able to find the IP address of Home Assistant Yellow on your router. The URL will be `http://<IP ADDRESS>` or `http://<IP ADDRESS>:8123`.
 
 2. Check if the Home Assistant Yellow is plugged in and the yellow LED blinks in a heartbeat pattern. For more information on the LED patterns, see [Home Assistant Yellow LEDs](/hc/en-us/articles/25410366475165-About-the-LEDs).
 


### PR DESCRIPTION
New installations of Home Assistant OS default to port 80 from the 2026.8 release. Existing installations are unchanged and keep :8123, so instructions need to cover both.

Primary addresses now omit the port, with a fallback note pointing at :8123 for existing installs. The two "can't access the system" FAQ articles give both forms inline instead.

Article titles for those two FAQs drop ":8123" as well.